### PR TITLE
🧪 Add tests for HexEditor invalid input handling

### DIFF
--- a/packages/frontend/src/__tests__/HexEditor.test.ts
+++ b/packages/frontend/src/__tests__/HexEditor.test.ts
@@ -178,6 +178,38 @@ describe("HexEditor", () => {
       expect(updatedData).toBeDefined();
       expect(updatedData![0]).toBe(0x00);
     });
+
+    it("should ignore invalid hexadecimal input", () => {
+      const data = new Uint8Array([0x48]);
+      const editor = new HexEditor(container, data, true);
+
+      const changeHandler = vi.fn();
+      editor.addEventListener("change", changeHandler);
+
+      const inputs = container.querySelectorAll("input");
+      const input = inputs[0] as HTMLInputElement;
+
+      input.value = "G";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(changeHandler).not.toHaveBeenCalled();
+    });
+
+    it("should ignore input longer than 2 characters", () => {
+      const data = new Uint8Array([0x48]);
+      const editor = new HexEditor(container, data, true);
+
+      const changeHandler = vi.fn();
+      editor.addEventListener("change", changeHandler);
+
+      const inputs = container.querySelectorAll("input");
+      const input = inputs[0] as HTMLInputElement;
+
+      input.value = "123";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(changeHandler).not.toHaveBeenCalled();
+    });
   });
 
   describe("rendering layout", () => {


### PR DESCRIPTION
Added unit tests to `packages/frontend/src/__tests__/HexEditor.test.ts` to verify the behavior of `HexEditor` when receiving invalid hexadecimal input. The new tests ensure that input that doesn't match the expected hex format (0-9, A-F) or exceeds 2 characters is ignored and does not trigger a 'change' event.

---
*PR created automatically by Jules for task [6423362698077004335](https://jules.google.com/task/6423362698077004335) started by @hahwul*