### PR TITLE
test(frontend): add unit tests for init function

### DIFF
--- a/packages/frontend/src/__tests__/index.test.ts
+++ b/packages/frontend/src/__tests__/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { init } from "../index";
+import type { FrontendSDK } from "../types";
+import HexViewMode from "../views/HexViewMode.vue";
+
+describe("init", () => {
+  it("should register Hex view mode for all SDK components", () => {
+    const httpHistoryMock = vi.fn();
+    const replayMock = vi.fn();
+    const searchMock = vi.fn();
+    const sitemapMock = vi.fn();
+
+    const sdk: FrontendSDK = {
+      httpHistory: { addRequestViewMode: httpHistoryMock },
+      replay: { addRequestViewMode: replayMock },
+      search: { addRequestViewMode: searchMock },
+      sitemap: { addRequestViewMode: sitemapMock },
+    } as unknown as FrontendSDK;
+
+    init(sdk);
+
+    const mocks = [httpHistoryMock, replayMock, searchMock, sitemapMock];
+
+    mocks.forEach((mock) => {
+      expect(mock).toHaveBeenCalledTimes(1);
+      const options = mock.mock.calls[0][0];
+
+      expect(options.label).toBe("Hex");
+      expect(options.view.component).toBe(HexViewMode);
+
+      // Test condition
+      expect(options.condition({ raw: "data" })).toBe(true);
+      expect(options.condition({ raw: "" })).toBe(false);
+      expect(options.condition({})).toBe(false);
+      expect(options.condition(null)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for the `init` function in `packages/frontend/src/index.ts`.
It mocks the `FrontendSDK` interface and verifies that the `addRequestViewMode` method is called for all relevant SDK components (`httpHistory`, `replay`, `search`, `sitemap`).
It also tests the `condition` function passed to `addRequestViewMode` to ensure correct behavior (showing the view mode only when `data.raw` is present).

Coverage:
- `init` function calls to SDK components.
- `condition` logic for view mode visibility.

Result:
- Improved test coverage for the plugin initialization logic.

---
*PR created automatically by Jules for task [12478920082541978624](https://jules.google.com/task/12478920082541978624) started by @hahwul*