### PR TITLE
test(frontend): add tests for SDKPlugin and useSDK

### DIFF
--- a/packages/frontend/src/__tests__/sdk.test.ts
+++ b/packages/frontend/src/__tests__/sdk.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import type { App } from "vue";
+import { SDKPlugin, useSDK } from "../plugins/sdk";
+import type { FrontendSDK } from "../types";
+
+describe("SDKPlugin", () => {
+  it("registers the SDK with the app", () => {
+    const app = {
+      provide: vi.fn(),
+    } as unknown as App;
+    const sdk = {} as FrontendSDK;
+
+    SDKPlugin(app, sdk);
+
+    expect(app.provide).toHaveBeenCalledTimes(1);
+    expect(app.provide).toHaveBeenCalledWith(expect.any(Symbol), sdk);
+  });
+
+  it("provides the SDK to components via useSDK", () => {
+    const sdk = { foo: "bar" } as unknown as FrontendSDK;
+
+    const TestComponent = {
+      template: "<div></div>",
+      setup() {
+        const injectedSdk = useSDK();
+        return { injectedSdk };
+      },
+    };
+
+    const wrapper = mount(TestComponent, {
+      global: {
+        plugins: [[SDKPlugin, sdk]],
+      },
+    });
+
+    expect(wrapper.vm.injectedSdk).toBe(sdk);
+  });
+
+  it("returns undefined when SDK is not provided", () => {
+    const TestComponent = {
+      template: "<div></div>",
+      setup() {
+        const injectedSdk = useSDK();
+        return { injectedSdk };
+      },
+    };
+
+    const wrapper = mount(TestComponent);
+
+    expect(wrapper.vm.injectedSdk).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Add unit and integration tests for `SDKPlugin` and `useSDK` in `packages/frontend/src/plugins/sdk.ts`.
- Mocked `app` and `sdk` to verify `SDKPlugin` calls `app.provide` correctly.
- Used a test component and `mount` to verify `useSDK` retrieves the provided SDK.
- Verified `useSDK` returns undefined when SDK is not provided.

---
*PR created automatically by Jules for task [13164026138767833179](https://jules.google.com/task/13164026138767833179) started by @hahwul*