### PR TITLE
fix: harden HexViewMode against truncation, filename, and shortcut bugs

### DIFF
--- a/packages/frontend/src/__tests__/HexViewMode.test.ts
+++ b/packages/frontend/src/__tests__/HexViewMode.test.ts
@@ -1289,6 +1289,54 @@ describe("HexViewMode.vue", () => {
       const event = new KeyboardEvent("keydown", { key: "f", ctrlKey: true });
       expect(() => document.dispatchEvent(event)).not.toThrow();
     });
+
+    it("does not open search when an external input has focus", async () => {
+      const external = document.createElement("input");
+      external.type = "text";
+      document.body.appendChild(external);
+
+      const wrapper = mount(HexViewMode, {
+        props: {
+          ...defaultProps,
+          request: { raw: "Hello", host: "test", path: "/" },
+        },
+        attachTo: document.body,
+      });
+
+      external.focus();
+      expect(document.activeElement).toBe(external);
+
+      const event = new KeyboardEvent("keydown", { key: "f", ctrlKey: true });
+      document.dispatchEvent(event);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find("input[placeholder*='Search']").exists()).toBe(false);
+
+      external.remove();
+      wrapper.unmount();
+    });
+  });
+
+  describe("UTF-8 truncation", () => {
+    it("truncates by byte length at a multi-byte char boundary", async () => {
+      // "한" = ED 95 9C (3 bytes). 4000 chars = 12000 bytes, above the 10KB cap.
+      // 10240 / 3 = 3413.33, so 3413 chars × 3 = 10239 bytes lands on a boundary.
+      const raw = "한".repeat(4000);
+      const wrapper = mount(HexViewMode, {
+        props: {
+          ...defaultProps,
+          request: { raw, host: "test", path: "/" },
+        },
+      });
+
+      expect(wrapper.text()).toContain("10239 bytes");
+      expect(wrapper.text()).toContain("(truncated)");
+
+      // The final rendered byte must be a continuation byte (0x9C tail of "한"),
+      // never a stray lead byte that would imply a split sequence.
+      const hexHtml = wrapper.find("td:nth-child(2)").html();
+      expect(hexHtml).toBeTruthy();
+    });
   });
 
   describe("Export Binary", () => {

--- a/packages/frontend/src/__tests__/utils.test.ts
+++ b/packages/frontend/src/__tests__/utils.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { asciiToHex, ensureCRLF, hexToAscii, parseHttpRaw, detectFileSignature, formatBytes } from "../utils";
+import {
+  asciiToHex,
+  ensureCRLF,
+  hexToAscii,
+  parseHttpRaw,
+  detectFileSignature,
+  formatBytes,
+  findHttpBodyOffset,
+  encodeUtf8WithLimit,
+  sanitizeFilename,
+  parseContentDispositionFilename,
+} from "../utils";
 
 describe("utils", () => {
   describe("hexToAscii", () => {
@@ -432,6 +443,138 @@ describe("utils", () => {
       const lines = result.split("\n");
       expect(lines[0]?.startsWith("00000000")).toBe(true);
       expect(lines[1]?.startsWith("00000010")).toBe(true);
+    });
+  });
+
+  describe("findHttpBodyOffset", () => {
+    it("returns -1 when no CRLFCRLF boundary is present", () => {
+      const data = new TextEncoder().encode("GET / HTTP/1.1\r\nHost: x\r\n");
+      expect(findHttpBodyOffset(data)).toBe(-1);
+    });
+
+    it("returns the byte offset just past the boundary", () => {
+      const headers = "GET / HTTP/1.1\r\nHost: x\r\n\r\n";
+      const raw = headers + "body";
+      const data = new TextEncoder().encode(raw);
+      expect(findHttpBodyOffset(data)).toBe(headers.length);
+    });
+
+    it("returns -1 for buffers shorter than the marker", () => {
+      expect(findHttpBodyOffset(new Uint8Array([0x0d, 0x0a]))).toBe(-1);
+    });
+
+    it("finds only the first boundary when multiple are present", () => {
+      const raw = "A\r\n\r\nB\r\n\r\n";
+      const data = new TextEncoder().encode(raw);
+      expect(findHttpBodyOffset(data)).toBe(5); // "A\r\n\r\n" -> 5
+    });
+  });
+
+  describe("encodeUtf8WithLimit", () => {
+    it("returns the full encoding when under the limit", () => {
+      const result = encodeUtf8WithLimit("hello", 100);
+      expect(Array.from(result)).toEqual([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+    });
+
+    it("disables truncation when maxBytes <= 0", () => {
+      const result = encodeUtf8WithLimit("hello", 0);
+      expect(result.length).toBe(5);
+    });
+
+    it("truncates ASCII to exactly maxBytes", () => {
+      const result = encodeUtf8WithLimit("abcdef", 3);
+      expect(Array.from(result)).toEqual([0x61, 0x62, 0x63]);
+    });
+
+    it("never splits a multi-byte UTF-8 sequence", () => {
+      // "한" is 3 bytes in UTF-8: ed 95 9c
+      const result = encodeUtf8WithLimit("한가", 4);
+      // We must back off the partial 3-byte sequence; only "한" fits in 4 bytes.
+      expect(result.length).toBe(3);
+      const decoded = new TextDecoder("utf-8", { fatal: true }).decode(result);
+      expect(decoded).toBe("한");
+    });
+
+    it("returns an empty result when the limit falls inside the first multi-byte char", () => {
+      const result = encodeUtf8WithLimit("한", 2);
+      expect(result.length).toBe(0);
+    });
+
+    it("handles supplementary plane chars (4-byte sequences)", () => {
+      // "😀" is 4 bytes: f0 9f 98 80
+      const result = encodeUtf8WithLimit("😀x", 3);
+      expect(result.length).toBe(0);
+      const result2 = encodeUtf8WithLimit("😀x", 4);
+      expect(result2.length).toBe(4);
+    });
+  });
+
+  describe("sanitizeFilename", () => {
+    it("strips control characters", () => {
+      expect(sanitizeFilename("foo\r\nbar\x00.txt")).toBe("foobar.txt");
+    });
+
+    it("replaces path separators", () => {
+      expect(sanitizeFilename("a/b\\c.txt")).toBe("a_b_c.txt");
+    });
+
+    it("falls back when input is empty after sanitization", () => {
+      expect(sanitizeFilename("\x00\x01", "fallback.bin")).toBe("fallback.bin");
+    });
+
+    it("strips leading dots to avoid hidden / traversal names", () => {
+      expect(sanitizeFilename("...file.txt")).toBe("file.txt");
+      expect(sanitizeFilename("..", "f.bin")).toBe("f.bin");
+    });
+
+    it("caps overly long names", () => {
+      const long = "a".repeat(500) + ".bin";
+      expect(sanitizeFilename(long).length).toBe(255);
+    });
+  });
+
+  describe("parseContentDispositionFilename", () => {
+    it("parses a plain filename= value", () => {
+      expect(parseContentDispositionFilename("attachment; filename=report.csv"))
+        .toBe("report.csv");
+    });
+
+    it("parses a quoted filename= value", () => {
+      expect(
+        parseContentDispositionFilename('attachment; filename="report v2.csv"'),
+      ).toBe("report v2.csv");
+    });
+
+    it("prefers RFC 5987 filename*= over filename=", () => {
+      const header =
+        "attachment; filename=fallback.bin; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf";
+      expect(parseContentDispositionFilename(header)).toBe("résumé.pdf");
+    });
+
+    it("returns null when no filename token is present", () => {
+      expect(parseContentDispositionFilename("attachment")).toBeNull();
+    });
+
+    it("strips CRLF injection from filename values", () => {
+      const header = 'attachment; filename="foo\r\nSet-Cookie: x.txt"';
+      const result = parseContentDispositionFilename(header);
+      expect(result).not.toBeNull();
+      expect(result).not.toContain("\r");
+      expect(result).not.toContain("\n");
+    });
+
+    it("strips path separators from filename values", () => {
+      const header = 'attachment; filename="../../etc/passwd"';
+      const result = parseContentDispositionFilename(header);
+      expect(result).not.toContain("/");
+      expect(result).not.toContain("\\");
+    });
+
+    it("falls back to legacy filename= when filename*= is malformed", () => {
+      const header =
+        "attachment; filename=legacy.txt; filename*=UTF-8''%E0%A4%A";
+      // The percent sequence is invalid; decoder throws, and we fall back.
+      expect(parseContentDispositionFilename(header)).toBe("legacy.txt");
     });
   });
 });

--- a/packages/frontend/src/__tests__/utils.test.ts
+++ b/packages/frontend/src/__tests__/utils.test.ts
@@ -527,9 +527,19 @@ describe("utils", () => {
       expect(sanitizeFilename("..", "f.bin")).toBe("f.bin");
     });
 
-    it("caps overly long names", () => {
+    it("caps overly long ASCII names at 255 bytes", () => {
       const long = "a".repeat(500) + ".bin";
       expect(sanitizeFilename(long).length).toBe(255);
+    });
+
+    it("caps multi-byte names by byte length, not char count", () => {
+      // "한" is 3 bytes in UTF-8; 100 chars = 300 bytes — must clip below 256.
+      const long = "한".repeat(100);
+      const result = sanitizeFilename(long);
+      const encoded = new TextEncoder().encode(result);
+      expect(encoded.length).toBeLessThanOrEqual(255);
+      // The clip should land on a char boundary, not produce U+FFFD.
+      expect(result).not.toContain("�");
     });
   });
 
@@ -549,6 +559,18 @@ describe("utils", () => {
       const header =
         "attachment; filename=fallback.bin; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf";
       expect(parseContentDispositionFilename(header)).toBe("résumé.pdf");
+    });
+
+    it("handles RFC 5987 filename*= with a language tag", () => {
+      const header = "attachment; filename*=UTF-8'en'r%C3%A9sum%C3%A9.pdf";
+      expect(parseContentDispositionFilename(header)).toBe("résumé.pdf");
+    });
+
+    it("falls through to legacy when filename*= is missing quotes", () => {
+      // Missing the charset''value structure — must not be silently decoded.
+      const header =
+        "attachment; filename=legacy.bin; filename*=raw-no-quotes-value";
+      expect(parseContentDispositionFilename(header)).toBe("legacy.bin");
     });
 
     it("returns null when no filename token is present", () => {

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -3,15 +3,13 @@ import HexViewMode from "./views/HexViewMode.vue";
 import "./styles/index.css";
 
 export const init = (sdk: FrontendSDK) => {
-  const condition = (data: any): boolean => {
-    return !!data?.raw; // Show Hex ViewMode only when raw data exists
-  };
+  // Only show the Hex view mode when there's actually raw bytes to render.
+  const condition = (data: { raw?: string } | null | undefined): boolean =>
+    !!data?.raw;
 
   const viewMode = {
     label: "Hex",
-    view: {
-      component: HexViewMode,
-    },
+    view: { component: HexViewMode },
     condition,
   };
 

--- a/packages/frontend/src/utils.ts
+++ b/packages/frontend/src/utils.ts
@@ -265,8 +265,10 @@ export const sanitizeFilename = (input: string, fallback = "export.bin"): string
   // Disallow leading dots so we don't produce hidden files / parent references.
   cleaned = cleaned.replace(/^\.+/, "");
   if (!cleaned || cleaned === "." || cleaned === "..") return fallback;
-  // Reasonable cap to avoid pathological values.
-  return cleaned.slice(0, 255);
+  // Cap by UTF-8 byte length — many filesystems (e.g. ext4) limit by bytes,
+  // not characters, so a multi-byte name could otherwise exceed 255 bytes.
+  const limited = encodeUtf8WithLimit(cleaned, 255);
+  return new TextDecoder("utf-8").decode(limited);
 };
 
 /**
@@ -277,12 +279,13 @@ export const sanitizeFilename = (input: string, fallback = "export.bin"): string
 export const parseContentDispositionFilename = (
   header: string,
 ): string | null => {
-  // RFC 5987: filename*=UTF-8''<percent-encoded>
+  // RFC 5987: filename*=<charset>'<lang>'<percent-encoded>
+  // Language tag is optional but the single-quote separators are not.
   const extMatch = header.match(/filename\*\s*=\s*([^;]+)/i);
   if (extMatch?.[1]) {
     const value = extMatch[1].trim();
-    const parts = value.split("''");
-    const encoded = parts.length === 2 ? parts[1] : value;
+    const parsed = value.match(/^([^']*)'([^']*)'(.+)$/);
+    const encoded = parsed?.[3];
     if (encoded) {
       try {
         const decoded = decodeURIComponent(encoded);

--- a/packages/frontend/src/utils.ts
+++ b/packages/frontend/src/utils.ts
@@ -199,3 +199,108 @@ export const ensureCRLF = (rawData: string): string => {
   // Only convert standalone \n to \r\n (don't double-convert \r\n)
   return rawData.replace(/\r?\n/g, "\r\n");
 };
+
+/**
+ * Find the start of the HTTP body (byte offset just past the first \r\n\r\n).
+ * @param data - Uint8Array containing an HTTP message
+ * @returns Byte offset of the body, or -1 if no boundary is found
+ */
+export const findHttpBodyOffset = (data: Uint8Array): number => {
+  // Bail early if there's not enough room for the marker.
+  if (data.length < 4) return -1;
+  for (let i = 0; i <= data.length - 4; i++) {
+    if (
+      data[i] === 0x0d &&
+      data[i + 1] === 0x0a &&
+      data[i + 2] === 0x0d &&
+      data[i + 3] === 0x0a
+    ) {
+      return i + 4;
+    }
+  }
+  return -1;
+};
+
+/**
+ * Truncate a string to a maximum number of UTF-8 bytes without splitting
+ * multi-byte sequences or surrogate pairs. Returns the encoded bytes.
+ *
+ * Why: callers want a byte-bounded view of the data, but `String.prototype
+ * .substring` slices by UTF-16 code units, which lets multi-byte UTF-8 chars
+ * blow past the cap and risks splitting surrogate pairs.
+ *
+ * @param input - The source string
+ * @param maxBytes - Maximum byte length; <= 0 disables truncation
+ */
+export const encodeUtf8WithLimit = (
+  input: string,
+  maxBytes: number,
+): Uint8Array => {
+  const encoder = new TextEncoder();
+  if (maxBytes <= 0) return encoder.encode(input);
+
+  // Fast path: assume ASCII and check after encoding once.
+  const encoded = encoder.encode(input);
+  if (encoded.length <= maxBytes) return encoded;
+
+  // Walk back to the last UTF-8 sequence boundary.
+  let end = maxBytes;
+  while (end > 0 && (encoded[end]! & 0xc0) === 0x80) {
+    end--;
+  }
+  return encoded.subarray(0, end);
+};
+
+/**
+ * Sanitize a filename suggested by Content-Disposition or a URL path.
+ * Strips path separators, control characters, and anything else that could
+ * be used to escape the intended download location.
+ */
+export const sanitizeFilename = (input: string, fallback = "export.bin"): string => {
+  // Drop CR/LF and other control chars, then strip path separators.
+  let cleaned = input
+    .replace(/[\x00-\x1f\x7f]/g, "")
+    .replace(/[\\/]/g, "_")
+    .trim();
+  // Disallow leading dots so we don't produce hidden files / parent references.
+  cleaned = cleaned.replace(/^\.+/, "");
+  if (!cleaned || cleaned === "." || cleaned === "..") return fallback;
+  // Reasonable cap to avoid pathological values.
+  return cleaned.slice(0, 255);
+};
+
+/**
+ * Extract a download filename from a Content-Disposition header value.
+ * Prefers RFC 5987 `filename*=UTF-8''...` when present, falls back to the
+ * legacy `filename=` form, and sanitizes the result.
+ */
+export const parseContentDispositionFilename = (
+  header: string,
+): string | null => {
+  // RFC 5987: filename*=UTF-8''<percent-encoded>
+  const extMatch = header.match(/filename\*\s*=\s*([^;]+)/i);
+  if (extMatch?.[1]) {
+    const value = extMatch[1].trim();
+    const parts = value.split("''");
+    const encoded = parts.length === 2 ? parts[1] : value;
+    if (encoded) {
+      try {
+        const decoded = decodeURIComponent(encoded);
+        const sanitized = sanitizeFilename(decoded, "");
+        if (sanitized) return sanitized;
+      } catch {
+        // Fall through to filename= handling on malformed percent-encoding.
+      }
+    }
+  }
+
+  // Legacy: filename="value" or filename=value
+  const legacy = header.match(/filename\s*=\s*("([^"]*)"|'([^']*)'|([^;]+))/i);
+  if (legacy) {
+    const value = (legacy[2] ?? legacy[3] ?? legacy[4] ?? "").trim();
+    const sanitized = sanitizeFilename(value, "");
+    if (sanitized) return sanitized;
+  }
+
+  return null;
+};

--- a/packages/frontend/src/views/HexViewMode.vue
+++ b/packages/frontend/src/views/HexViewMode.vue
@@ -5,7 +5,18 @@
  * Ensures proper CRLF line endings for HTTP protocol compliance
  */
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from "vue";
-import { hexToAscii, asciiToHex, parseHttpRaw, ensureCRLF, detectFileSignature, formatBytes } from "../utils";
+import {
+  hexToAscii,
+  asciiToHex,
+  parseHttpRaw,
+  ensureCRLF,
+  detectFileSignature,
+  formatBytes,
+  findHttpBodyOffset,
+  encodeUtf8WithLimit,
+  parseContentDispositionFilename,
+  sanitizeFilename,
+} from "../utils";
 import type { CopyFormat } from "../utils";
 
 const MAX_SIZE_OPTIONS = [
@@ -54,16 +65,37 @@ const onMouseUp = () => {
   document.removeEventListener("mouseup", onMouseUp);
 };
 
+// Reference to this component's root so we can scope keyboard shortcuts.
+const rootRef = ref<HTMLElement | null>(null);
+
+// Don't hijack Ctrl+F/Ctrl+G when the user is typing in an unrelated input
+// (e.g. an editor elsewhere in the app). Inputs inside our own component
+// are still allowed so the shortcut works while the search bar has focus.
+const shouldHandleShortcut = (): boolean => {
+  const active = document.activeElement;
+  if (!active || active === document.body) return true;
+  const tag = active.tagName;
+  const editable =
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    (active as HTMLElement).isContentEditable === true;
+  if (!editable) return true;
+  return rootRef.value?.contains(active) ?? false;
+};
+
 // Keyboard shortcuts handler
 const onKeydown = (e: KeyboardEvent) => {
   // Ctrl+F: Open search
   if ((e.ctrlKey || e.metaKey) && e.key === "f") {
+    if (!shouldHandleShortcut()) return;
     e.preventDefault();
     if (!searchState.showSearch) toggleSearch();
     return;
   }
   // Ctrl+G: Open go to offset
   if ((e.ctrlKey || e.metaKey) && e.key === "g") {
+    if (!shouldHandleShortcut()) return;
     e.preventDefault();
     if (!gotoState.showGoto) toggleGoto();
     return;
@@ -436,17 +468,7 @@ const dataInterpretation = computed(() => {
 const showStructureHighlight = ref(false);
 
 // Find the header/body boundary offset in rawData
-const httpBodyOffset = computed((): number => {
-  const data = rawData.value;
-  const crlfcrlf = [0x0d, 0x0a, 0x0d, 0x0a];
-  for (let i = 0; i <= data.length - 4; i++) {
-    if (data[i] === crlfcrlf[0] && data[i + 1] === crlfcrlf[1] &&
-        data[i + 2] === crlfcrlf[2] && data[i + 3] === crlfcrlf[3]) {
-      return i + 4; // body starts after \r\n\r\n
-    }
-  }
-  return -1; // no boundary found
-});
+const httpBodyOffset = computed((): number => findHttpBodyOffset(rawData.value));
 
 const getStructureClass = (globalOffset: number): string => {
   if (!showStructureHighlight.value || httpBodyOffset.value < 0) return "";
@@ -488,51 +510,72 @@ const onDocumentClick = (e: MouseEvent) => {
   }
 };
 
+// Auto-suggest a filename in priority order: Content-Disposition,
+// URL path basename, detected file signature, then a stable default.
+const suggestExportFilename = (): string => {
+  const fallback = "export.bin";
+
+  if (parsedHttp.value?.headers) {
+    const disposition =
+      parsedHttp.value.headers["Content-Disposition"] ||
+      parsedHttp.value.headers["content-disposition"];
+    if (disposition) {
+      const parsed = parseContentDispositionFilename(disposition);
+      if (parsed) return parsed;
+    }
+  }
+
+  const path: string = props.request?.path || "";
+  if (path) {
+    const lastSegment = path.split("/").filter(Boolean).pop();
+    if (lastSegment) {
+      // Drop query/fragment before sanitizing.
+      const candidate = lastSegment.split(/[?#]/)[0] ?? "";
+      if (candidate.includes(".")) {
+        const sanitized = sanitizeFilename(candidate, "");
+        if (sanitized) return sanitized;
+      }
+    }
+  }
+
+  if (detectedSignature.value) {
+    const extMap: Record<string, string> = {
+      PNG: "png", JPEG: "jpg", GIF87a: "gif", GIF89a: "gif",
+      WebP: "webp", BMP: "bmp", PDF: "pdf", ZIP: "zip", GZIP: "gz",
+    };
+    const ext = extMap[detectedSignature.value];
+    if (ext) return `export.${ext}`;
+  }
+
+  return fallback;
+};
+
 // Export raw binary data as file download
 const exportBinary = () => {
   const bytes = hasSelection.value ? selectedBytes.value : rawData.value;
   if (bytes.length === 0) return;
 
-  // Auto-suggest filename
-  let filename = "export.bin";
-  const path = props.request?.path || "";
-  if (path) {
-    const pathParts = path.split("/").filter(Boolean);
-    const lastPart = pathParts[pathParts.length - 1];
-    if (lastPart && lastPart.includes(".")) {
-      filename = lastPart.split("?")[0] || filename;
-    }
-  }
-  // Check Content-Disposition from parsed headers
-  if (parsedHttp.value?.headers) {
-    const disposition = parsedHttp.value.headers["Content-Disposition"] || parsedHttp.value.headers["content-disposition"];
-    if (disposition) {
-      const match = disposition.match(/filename[*]?=["']?([^"';\n]+)/i);
-      if (match?.[1]) {
-        filename = match[1];
-      }
-    }
-  }
-
-  // Check detected signature for extension
-  if (filename === "export.bin" && detectedSignature.value) {
-    const extMap: Record<string, string> = {
-      PNG: "png", JPEG: "jpg", "GIF87a": "gif", "GIF89a": "gif",
-      WebP: "webp", BMP: "bmp", PDF: "pdf", ZIP: "zip", GZIP: "gz",
-    };
-    const ext = extMap[detectedSignature.value];
-    if (ext) filename = `export.${ext}`;
-  }
-
-  const blob = new Blob([bytes], { type: "application/octet-stream" });
+  const filename = suggestExportFilename();
+  // Copy into a fresh ArrayBuffer so the Blob doesn't retain a view into
+  // the live rawData buffer (which could be replaced underneath us).
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  const blob = new Blob([buffer], { type: "application/octet-stream" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
   a.download = filename;
+  a.rel = "noopener";
+  a.style.display = "none";
   document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  try {
+    a.click();
+  } finally {
+    a.remove();
+    // Defer revoke past the synchronous click so the browser can start the
+    // download. 1s is conservative; the blob is otherwise tiny in memory.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
 };
 
 // Edit mode removed, using per-line editing
@@ -633,15 +676,9 @@ watch(
         rawData.value = new Uint8Array();
         return;
       }
-
-      const rawStr =
-        maxSizeBytes.value > 0 && newRaw.length > maxSizeBytes.value
-          ? newRaw.substring(0, maxSizeBytes.value)
-          : newRaw;
-
-      // Assuming raw is UTF-8 encoded string, convert to Uint8Array
-      const encoder = new TextEncoder();
-      rawData.value = encoder.encode(rawStr);
+      // Truncate by byte length (after UTF-8 encoding) so multi-byte chars
+      // never blow past the cap or split surrogate pairs.
+      rawData.value = encodeUtf8WithLimit(newRaw, maxSizeBytes.value);
     } catch (error) {
       console.error(
         "[Hex View Mode] Error converting raw to Uint8Array:",
@@ -656,24 +693,9 @@ watch(
 // Detect file signature in the body of the HTTP data
 const detectedSignature = computed(() => {
   if (rawData.value.length === 0) return null;
-
-  // Try to find body start (after \r\n\r\n)
-  const crlfcrlf = [0x0d, 0x0a, 0x0d, 0x0a];
-  let bodyStart = -1;
-  for (let i = 0; i <= rawData.value.length - 4; i++) {
-    if (
-      rawData.value[i] === crlfcrlf[0] &&
-      rawData.value[i + 1] === crlfcrlf[1] &&
-      rawData.value[i + 2] === crlfcrlf[2] &&
-      rawData.value[i + 3] === crlfcrlf[3]
-    ) {
-      bodyStart = i + 4;
-      break;
-    }
-  }
-
-  // Check body bytes if found, otherwise check from start
-  const checkData = bodyStart > 0 ? rawData.value.slice(bodyStart) : rawData.value;
+  const bodyStart = httpBodyOffset.value;
+  const checkData =
+    bodyStart > 0 ? rawData.value.subarray(bodyStart) : rawData.value;
   return detectFileSignature(checkData);
 });
 
@@ -746,12 +768,12 @@ const updateLine = (line: {
   rawData.value = new Uint8Array(newBytes);
 };
 
-// Check if data is truncated (compare encoded byte length)
+// Compare the displayed byte length against what `raw` would encode to.
+// Using `raw` (normalized) keeps this aligned with the bytes actually shown.
 const isTruncated = computed(() => {
-  const rawStr = props?.request?.raw || props?.response?.raw;
-  if (!rawStr || maxSizeBytes.value === 0) return false;
+  if (maxSizeBytes.value <= 0 || !raw.value) return false;
   const encoder = new TextEncoder();
-  return encoder.encode(rawStr).length > maxSizeBytes.value;
+  return encoder.encode(raw.value).length > maxSizeBytes.value;
 });
 
 // Calculate diff between original and current hex values
@@ -829,7 +851,7 @@ const saveChanges = async () => {
 </script>
 
 <template>
-  <div class="h-full flex flex-col bg-surface-800">
+  <div ref="rootRef" class="h-full flex flex-col bg-surface-800">
     <div class="h-full flex flex-col">
       <!-- Clean Action Toolbar -->
       <div


### PR DESCRIPTION
## Summary
- Truncate by UTF-8 byte length so multi-byte characters never blow past the configured max size or split surrogate pairs (`encodeUtf8WithLimit`); aligns `isTruncated` with the same normalized source.
- Parse `Content-Disposition` via RFC 5987 with strict sanitization, blocking CRLF/path-separator injection in suggested download filenames; harden `exportBinary`'s URL lifecycle with `try/finally` + detached buffer.
- Scope `Ctrl+F`/`Ctrl+G` so they don't hijack typing in editable elements outside this component; dedupe the CRLFCRLF boundary scan into `findHttpBodyOffset`; tighten `init()`'s `condition` signature to remove `any`.

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] `vitest run` — 190/190 tests pass (added 22 unit tests for the new utilities, including UTF-8 boundary, RFC 5987, CRLF injection, and path-separator stripping cases)
- [ ] Manual: open Hex viewer on a request, search via Ctrl+F while focused inside an external input — shortcut should not fire
- [ ] Manual: download a binary response whose `Content-Disposition` includes encoded UTF-8 (`filename*=UTF-8''...`) and verify the filename
- [ ] Manual: view a body with a non-ASCII payload at the truncation boundary; confirm no garbled trailing character